### PR TITLE
change Search By City response message and 

### DIFF
--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -36,7 +36,7 @@ namespace Bangazon.Controllers
                 var products = from p in _context.Product
                                select p;
 
-                var filteredProducts = products.Where(p => p.Title == searchString);
+                var filteredProducts = products.Where(p => p.Title.Contains(searchString));
 
                 return View(await filteredProducts.ToListAsync());
             }

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -36,7 +36,8 @@ namespace Bangazon.Controllers
                 var products = from p in _context.Product
                                select p;
 
-                var filteredProducts = products.Where(p => p.Title.Contains(searchString));
+                var filteredProducts = products.Where(p => p.Title == searchString);
+
                 return View(await filteredProducts.ToListAsync());
             }
             else // List products
@@ -47,17 +48,18 @@ namespace Bangazon.Controllers
         }
 
 
-        public async Task<IActionResult> ProductsByCity(string searchByCity)
+        public async Task<IActionResult> ProductsByCity(string city)
         {
             //List products by city search results
             var products = from p in _context.Product
                                select p;
-            if (!String.IsNullOrEmpty(searchByCity))
+            if (!String.IsNullOrEmpty(city))
             {
-                var filteredProducts = products.Where(p => p.City == searchByCity);
+                var filteredProducts = products.Where(p => p.City == city);
                 int filteredProductsCount = filteredProducts.Count();
                 if (filteredProductsCount > 0)
                 {
+                    ViewData["city"] = city;
                     return View(await filteredProducts.ToListAsync());
                 }
                 else

--- a/Bangazon/Views/Home/Index.cshtml
+++ b/Bangazon/Views/Home/Index.cshtml
@@ -16,7 +16,7 @@
 <form asp-controller="Products" asp-action="ProductsByCity" method="get">
     <div class="form-actions no-color">
         <p>
-            <input pattern=".{1,}"   required title="1 characters minimum" type="text" name="SearchByCity" placeholder="Filter Products By City" value="@ViewData["CurrentFilter"]" />
+            <input pattern=".{1,}"   required title="1 characters minimum" type="text" name="city" placeholder="Filter Products By City" value="@ViewData["CurrentFilter"]" />
             <input type="submit" value="Search" class="btn btn-default" />
         </p>
     </div>

--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -70,6 +70,6 @@
     </div>
 </div>
 <div>
-    <a asp-action="Edit" asp-route-id="@Model.ProductId">Edit</a> |
+    @*<a asp-action="Edit" asp-route-id="@Model.ProductId">Edit</a> |*@
     <a asp-action="Index">Back to List</a>
 </div>

--- a/Bangazon/Views/Products/ProductsByCity.cshtml
+++ b/Bangazon/Views/Products/ProductsByCity.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "ProductsByCity";
 }
 
-<h1>ProductsByCity</h1>
+    <h4>Product results for @ViewBag.city</h4>
 
 <table class="table">
     <thead>

--- a/Bangazon/Views/Products/Types.cshtml
+++ b/Bangazon/Views/Products/Types.cshtml
@@ -4,16 +4,16 @@
     ViewData["Title"] = "Types";
 }
 
-<h1>Product Categories</h1>
+<h4>Product Categories</h4>
 
 @foreach (var item in Model.GroupedProducts)
 {
-<h3>
+<p>
     <a asp-controller="Products" asp-action="ListProductByType" asp-route-id="@item.TypeId">
         @item.TypeName
         (@item.ProductCount)
         </a>
-</h3>
+</p>
     <ul>
         @foreach (var p in item.Products)
         {


### PR DESCRIPTION
removed Edit link from Product Details view

Changed Search By City Response:
From Home page:
1. Enter a city that is in the DB to see "Product results for {city}" and list of products for that city 
2. Enter a city that is not in the DB to see "City not found..."

Removed Edit link from Product Details view
(The only place to edit a product is now through MyProducts link in navbar)